### PR TITLE
feat(git-push): support tag-only configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ When configuring branches permission on a Git hosting service (e.g. [GitHub prot
 |-----------|------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------|
 | `message` | The message for the release commit. See [message](#message).                                                                 | `chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}`     |
 | `assets`  | Files to include in the release commit. Set to `false` to disable adding files to the release commit. See [assets](#assets). | `['CHANGELOG.md', 'package.json', 'package-lock.json', 'npm-shrinkwrap.json']` |
+| `tagOnly` | Indicates that we should push only to the tag, not to the full branch. | `false`
 
 #### `message`
 

--- a/lib/git.js
+++ b/lib/git.js
@@ -45,13 +45,19 @@ async function commit(message, execaOpts) {
  * Push to the remote repository.
  *
  * @param {String} origin The remote repository URL.
- * @param {String} branch The branch to push.
+ * @param {String} [branch] The branch to push.
  * @param {Object} [execaOpts] Options to pass to `execa`.
  *
  * @throws {Error} if the push failed.
  */
 async function push(origin, branch, execaOpts) {
-  await execa('git', ['push', '--tags', origin, `HEAD:${branch}`], execaOpts);
+  const args = ['push', '--tags', origin];
+
+  if (typeof branch === 'string' && branch.length > 0) {
+    args.push(`HEAD:${branch}`);
+  }
+
+  await execa('git', args, execaOpts);
 }
 
 /**

--- a/lib/prepare.js
+++ b/lib/prepare.js
@@ -10,6 +10,7 @@ const {filterModifiedFiles, add, commit, push} = require('./git');
  * @param {Object} pluginConfig The plugin configuration.
  * @param {String|Array<String>} [pluginConfig.assets] Files to include in the release commit. Can be files path or globs.
  * @param {String} [pluginConfig.message] The message for the release commit.
+ * @param {Boolean} [pluginConfig.tagOnly] Indicates that we should push only to the tag, not to the full branch.
  * @param {Object} context semantic-release context.
  * @param {Object} context.options `semantic-release` configuration.
  * @param {Object} context.lastRelease The last release.
@@ -25,7 +26,7 @@ module.exports = async (pluginConfig, context) => {
     nextRelease,
     logger,
   } = context;
-  const {message, assets} = resolveConfig(pluginConfig, logger);
+  const {message, assets, tagOnly} = resolveConfig(pluginConfig, logger);
 
   if (assets && assets.length > 0) {
     const globbedAssets = await globAssets(context, assets);
@@ -45,7 +46,7 @@ module.exports = async (pluginConfig, context) => {
       );
     }
 
-    await push(repositoryUrl, branch, {env, cwd});
+    await push(repositoryUrl, tagOnly ? undefined : branch, {env, cwd});
     logger.log('Prepared Git release: %s', nextRelease.gitTag);
   }
 };

--- a/lib/resolve-config.js
+++ b/lib/resolve-config.js
@@ -1,10 +1,11 @@
 const {isNil, castArray} = require('lodash');
 
-module.exports = ({assets, message}) => ({
+module.exports = ({assets, message, tagOnly}) => ({
   assets: isNil(assets)
     ? ['CHANGELOG.md', 'package.json', 'package-lock.json', 'npm-shrinkwrap.json']
     : assets
     ? castArray(assets)
     : assets,
   message,
+  tagOnly: isNil(tagOnly) ? false : tagOnly,
 });

--- a/lib/verify.js
+++ b/lib/verify.js
@@ -7,22 +7,26 @@ const isNonEmptyString = value => isString(value) && value.trim();
 const isStringOrStringArray = value => isNonEmptyString(value) || (isArray(value) && value.every(isNonEmptyString));
 const isArrayOf = validator => array => isArray(array) && array.every(value => validator(value));
 const canBeDisabled = validator => value => value === false || validator(value);
+const isBool = value => typeof value === 'boolean';
 
 const VALIDATORS = {
   assets: canBeDisabled(
     isArrayOf(asset => isStringOrStringArray(asset) || (isPlainObject(asset) && isStringOrStringArray(asset.path)))
   ),
   message: isNonEmptyString,
+  tagOnly: isBool,
 };
 
 /**
- * Verify the commit `message` format and the `assets` option configuration:
+ * Verify the commit `message` format and the other options configuration:
  * - The commit `message`, is defined, must a non empty `String`.
  * - The `assets` configuration must be an `Array` of `String` (file path) or `false` (to disable).
+ * - The `tagOnly` configuration must be a `Boolean`. Defaults to `false`.
  *
  * @param {Object} pluginConfig The plugin configuration.
  * @param {String|Array<String|Object>} [pluginConfig.assets] Files to include in the release commit. Can be files path or globs.
  * @param {String} [pluginConfig.message] The commit message for the release.
+ * @param {Boolean} [pluginConfig.tagOnly] Indicates that we should push only to the tag, not to the full branch.
  */
 module.exports = pluginConfig => {
   const options = resolveConfig(pluginConfig);

--- a/test/git.test.js
+++ b/test/git.test.js
@@ -2,7 +2,15 @@ import path from 'path';
 import test from 'ava';
 import {outputFile, appendFile} from 'fs-extra';
 import {add, filterModifiedFiles, commit, gitHead, push} from '../lib/git';
-import {gitRepo, gitCommits, gitGetCommits, gitStaged, gitRemoteHead} from './helpers/git-utils';
+import {
+  gitRepo,
+  gitCommits,
+  gitGetCommits,
+  gitStaged,
+  gitRemoteHead,
+  gitGetTag,
+  gitTagVersion,
+} from './helpers/git-utils';
 
 test('Add file to index', async t => {
   // Create a git repository, set the current working directory at the root of the repo
@@ -95,4 +103,17 @@ test('Push commit to remote repository', async t => {
   await push(repositoryUrl, 'master', {cwd});
 
   t.is(await gitRemoteHead(repositoryUrl, {cwd}), hash);
+});
+
+test('Push only tags to remote repository', async t => {
+  // Create a git repository with a remote, set the current working directory at the root of the repo
+  const {cwd, repositoryUrl} = await gitRepo(true);
+  const [{hash}] = await gitCommits(['Test commit'], {cwd});
+
+  const testTagName = 'git.test.push-only-tags';
+  await gitTagVersion(testTagName, undefined, {cwd});
+  await push('origin', '', {cwd});
+
+  t.is(await gitGetTag(testTagName, {cwd}), hash);
+  t.not(await gitRemoteHead(repositoryUrl, {cwd}), hash);
 });

--- a/test/helpers/git-utils.js
+++ b/test/helpers/git-utils.js
@@ -112,6 +112,25 @@ export async function gitTagVersion(tagName, sha, execaOpts) {
 }
 
 /**
+ * Find the sha of an existing tag in the current git repository.
+ *
+ * @param {String} tagName
+ * @param {Object} [execaOpts]
+ */
+export async function gitGetTag(tagName, execaOpts) {
+  const command = await execa('git', ['ls-remote', '--tags', './.', tagName], execaOpts);
+  const shaAndRefs = command.stdout.split('\n');
+
+  if (shaAndRefs.length !== 1) {
+    throw new Error(`tag enumeration yielded incorrect number of results: ${shaAndRefs.length}: \n${command.stdout}`);
+  }
+
+  const firstShaAndRef = shaAndRefs[0];
+
+  return /(.+)\s/.exec(firstShaAndRef)[1];
+}
+
+/**
  * Create a shallow clone of a git repository and change the current working directory to the cloned repository root.
  * The shallow will contain a limited number of commit and no tags.
  *

--- a/test/verify.test.js
+++ b/test/verify.test.js
@@ -59,6 +59,10 @@ test('Verify "assets" is an Array of Object with a glob Arrays in path property'
   t.notThrows(() => verify({assets}));
 });
 
+test('Verify "tagOnly" is a bool', t => {
+  t.notThrows(() => verify({tagOnly: true}));
+});
+
 test('Throw SemanticReleaseError if "message" option is not a String', t => {
   const message = 42;
   const [error] = t.throws(() => verify({message}));
@@ -83,6 +87,6 @@ test('Throw SemanticReleaseError if "message" option is a whitespace String', t 
   t.is(error.code, 'EINVALIDMESSAGE');
 });
 
-test('Verify undefined "message" and "assets"', t => {
+test('Verify undefined "message", "assets", "tagOnly"', t => {
   t.notThrows(() => verify({}));
 });


### PR DESCRIPTION
Add support (downstream) for git-push to tag directly, but not to the branch. This creates a dangling commit much like the jquery dist/ distribution pattern.